### PR TITLE
Remove conflicting subtitle CSS

### DIFF
--- a/tzk/editions/tzk/tiddlers/_system/sib/styles/Subtitle.tid
+++ b/tzk/editions/tzk/tiddlers/_system/sib/styles/Subtitle.tid
@@ -8,6 +8,4 @@ type: text/vnd.tiddlywiki
 
 .tc-title { font-size: 0.9em; color: <<color tiddler-title-foreground>>; }
 
-.tc-subtitle { font-size: 0.9em; color: <<color tiddler-title-foreground>>; }
-
 .tc-subtitle .tc-tiddlylink { margin-right: 0; }


### PR DESCRIPTION
It conflicts with the main CSS for the tiddler subtitle, preventing the color chosen in the palette from taking effect.